### PR TITLE
Error handling overhaul

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "term"
-version = "0.2.14"
+version = "0.3.0"
 authors = ["The Rust Project Developers", "Steven Allen"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/terminfo/mod.rs
+++ b/src/terminfo/mod.rs
@@ -12,8 +12,6 @@
 
 use std::collections::HashMap;
 use std::env;
-use std::error;
-use std::fmt;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io;
@@ -23,9 +21,11 @@ use std::path::Path;
 use Attr;
 use color;
 use Terminal;
+use Result;
 use self::searcher::get_dbpath_for_term;
 use self::parser::compiled::{parse, msys_terminfo};
 use self::parm::{expand, Variables, Param};
+use self::Error::*;
 
 
 /// A parsed terminfo database entry.
@@ -41,47 +41,12 @@ pub struct TermInfo {
     pub strings: HashMap<String, Vec<u8> >
 }
 
-/// A terminfo creation error.
-#[derive(Debug)]
-pub enum Error {
-    /// TermUnset Indicates that the environment doesn't include enough information to find
-    /// the terminfo entry.
-    TermUnset,
-    /// MalformedTerminfo indicates that parsing the terminfo entry failed.
-    MalformedTerminfo(String),
-    /// io::Error forwards any io::Errors encountered when finding or reading the terminfo entry.
-    IoError(io::Error),
-}
-
-impl error::Error for Error {
-    fn description(&self) -> &str { "failed to create TermInfo" }
-
-    fn cause(&self) -> Option<&error::Error> {
-        use self::Error::*;
-        match self {
-            &IoError(ref e) => Some(e),
-            _ => None,
-        }
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::Error::*;
-        match self {
-            &TermUnset => Ok(()),
-            &MalformedTerminfo(ref e) => e.fmt(f),
-            &IoError(ref e) => e.fmt(f),
-        }
-    }
-}
-
 impl TermInfo {
     /// Create a TermInfo based on current environment.
-    pub fn from_env() -> Result<TermInfo, Error> {
+    pub fn from_env() -> Result<TermInfo> {
         let term = match env::var("TERM") {
             Ok(name) => TermInfo::from_name(&name),
-            Err(..) => return Err(Error::TermUnset),
+            Err(..) => return Err(::Error::TermUnset),
         };
 
         if term.is_err() && env::var("MSYSCON").ok().map_or(false, |s| "mintty.exe" == s) {
@@ -93,26 +58,96 @@ impl TermInfo {
     }
 
     /// Create a TermInfo for the named terminal.
-    pub fn from_name(name: &str) -> Result<TermInfo, Error> {
+    pub fn from_name(name: &str) -> Result<TermInfo> {
         get_dbpath_for_term(name).ok_or_else(|| {
-            Error::IoError(io::Error::new(io::ErrorKind::NotFound,
-                                          "terminfo file not found"))
+            ::Error::TerminfoEntryNotFound
         }).and_then(|p| {
             TermInfo::from_path(&p)
         })
     }
 
     /// Parse the given TermInfo.
-    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<TermInfo, Error> {
+    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<TermInfo> {
         Self::_from_path(path.as_ref())
     }
     // Keep the metadata small
-    fn _from_path(path: &Path) -> Result<TermInfo, Error> {
-        let file = try!(File::open(path).map_err(|e| { Error::IoError(e) }));
+    // (That is, this uses a &Path so that this function need not be instantiated for every type
+    // which implements AsRef<Path>. One day, if/when rustc is a bit smarter, it might do this for
+    // us. Alas. )
+    fn _from_path(path: &Path) -> Result<TermInfo> {
+        let file = try!(File::open(path).map_err(|e| { ::Error::Io(e) }));
         let mut reader = BufReader::new(file);
-        parse(&mut reader, false).map_err(|e| {
-            Error::MalformedTerminfo(e)
-        })
+        parse(&mut reader, false)
+    }
+}
+
+#[derive(Debug)]
+/// An error from parsing a terminfo entry
+pub enum Error {
+    /// The "magic" number at the start of the file was wrong.
+    ///
+    /// It should be `0x11A`
+    BadMagic(u16),
+    /// The names in the file were not valid UTF-8.
+    ///
+    /// In theory these should only be ASCII, but to work with the Rust `str` type, we treat them
+    /// as UTF-8. This is valid, except when a terminfo file decides to be invalid. This hasn't
+    /// been encountered in the wild.
+    NotUtf8(::std::str::Utf8Error),
+    /// The names section of the file was empty
+    ShortNames,
+    /// More boolean parameters are present in the file than this crate knows how to interpret.
+    TooManyBools,
+    /// More number parameters are present in the file than this crate knows how to interpret.
+    TooManyNumbers,
+    /// More string parameters are present in the file than this crate knows how to interpret.
+    TooManyStrings,
+    /// The length of some field was not >= -1.
+    InvalidLength,
+    /// The names table was missing a trailing null terminator.
+    NamesMissingNull,
+    /// The strings table was missing a trailing null terminator.
+    StringsMissingNull,
+
+}
+
+impl ::std::fmt::Display for Error {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        use std::error::Error;
+        match self {
+            &NotUtf8(e) => write!(f, "{}", e),
+            &BadMagic(v) => write!(f, "bad magic number {:x} in terminfo header", v),
+            _ => f.write_str(self.description())
+        }
+    }
+}
+
+impl ::std::convert::From<::std::string::FromUtf8Error> for Error {
+    fn from(v: ::std::string::FromUtf8Error) -> Self {
+        NotUtf8(v.utf8_error())
+    }
+}
+
+impl ::std::error::Error for Error {
+    fn description(&self) -> &str {
+        match self {
+            &BadMagic(..) => "incorrect magic number at start of file",
+            &ShortNames => "no names exposed, need at least one",
+            &TooManyBools => "more boolean properties than libterm knows about",
+            &TooManyNumbers => "more number properties than libterm knows about",
+            &TooManyStrings => "more string properties than libterm knows about",
+            &InvalidLength => "invalid length field value, must be >= -1",
+            &NotUtf8(ref e) => e.description(),
+            &NamesMissingNull => "names table missing NUL terminator",
+            &StringsMissingNull => "string table missing NUL terminator",
+        }
+    }
+
+    fn cause(&self) -> Option<&::std::error::Error> {
+        match self {
+            &NotUtf8(ref e) => Some(e),
+            _ => None
+        }
     }
 }
 
@@ -154,23 +189,23 @@ pub struct TerminfoTerminal<T> {
 
 impl<T: Write+Send> Terminal for TerminfoTerminal<T> {
     type Output = T;
-    fn fg(&mut self, color: color::Color) -> io::Result<bool> {
+    fn fg(&mut self, color: color::Color) -> Result<()> {
         let color = self.dim_if_necessary(color);
         if self.num_colors > color {
             return self.apply_cap("setaf", &[Param::Number(color as i32)]);
         }
-        Ok(false)
+        Err(::Error::ColorNotSupported)
     }
 
-    fn bg(&mut self, color: color::Color) -> io::Result<bool> {
+    fn bg(&mut self, color: color::Color) -> Result<()> {
         let color = self.dim_if_necessary(color);
         if self.num_colors > color {
             return self.apply_cap("setab", &[Param::Number(color as i32)]);
         }
-        Ok(false)
+        Err(::Error::ColorNotSupported)
     }
 
-    fn attr(&mut self, attr: Attr) -> io::Result<bool> {
+    fn attr(&mut self, attr: Attr) -> Result<()> {
         match attr {
             Attr::ForegroundColor(c) => self.fg(c),
             Attr::BackgroundColor(c) => self.bg(c),
@@ -190,8 +225,8 @@ impl<T: Write+Send> Terminal for TerminfoTerminal<T> {
         }
     }
 
-    fn reset(&mut self) -> io::Result<bool> {
-        // are there any terminals that have color/attrs and not sgr0?
+    fn reset(&mut self) -> Result<()> {
+        // are there any terminals that have color/attrs and not sg0?
         // Try falling back to sgr, then op
         let cmd = match [
             "sg0", "sgr", "op"
@@ -200,22 +235,23 @@ impl<T: Write+Send> Terminal for TerminfoTerminal<T> {
         }).next() {
             Some(op) => match expand(&op, &[], &mut Variables::new()) {
                 Ok(cmd) => cmd,
-                Err(e) => return Err(io::Error::new(io::ErrorKind::InvalidData, e))
+                Err(e) => return Err(e.into()),
             },
-            None => return Ok(false),
+            None => return Err(::Error::AttributeNotSupported),
         };
-        self.out.write_all(&cmd).and(Ok(true))
+        try!(self.out.write_all(&cmd));
+        Ok(())
     }
 
-    fn cursor_up(&mut self) -> io::Result<bool> {
+    fn cursor_up(&mut self) -> Result<()> {
         self.apply_cap("cuu1", &[])
     }
 
-    fn delete_line(&mut self) -> io::Result<bool> {
+    fn delete_line(&mut self) -> Result<()> {
         self.apply_cap("dl", &[])
     }
 
-    fn carriage_return(&mut self) -> io::Result<bool> {
+    fn carriage_return(&mut self) -> Result<()> {
         self.apply_cap("cr", &[])
     }
 
@@ -250,17 +286,19 @@ impl<T: Write+Send> TerminfoTerminal<T> {
 
     fn dim_if_necessary(&self, color: color::Color) -> color::Color {
         if color >= self.num_colors && color >= 8 && color < 16 {
-            color-8
-        } else { color }
+            color - 8
+        } else {
+            color
+        }
     }
 
-    fn apply_cap(&mut self, cmd: &str, params: &[Param]) -> io::Result<bool> {
+    fn apply_cap(&mut self, cmd: &str, params: &[Param]) -> Result<()> {
         match self.ti.strings.get(cmd) {
             Some(cmd) => match expand(&cmd, params, &mut Variables::new()) {
-                Ok(s) => self.out.write_all(&s).and(Ok(true)),
-                Err(e) => Err(io::Error::new(io::ErrorKind::InvalidData, e)),
+                Ok(s) => { try!(self.out.write_all(&s)); Ok(()) }
+                Err(e) => Err(e.into()),
             },
-            None => Ok(false)
+            None => Err(::Error::AttributeNotSupported)
         }
     }
 }


### PR DESCRIPTION
This yanks out all the String types in Results and replaces them
with fine-grained enums.

Closes #45
